### PR TITLE
✏️  Amend spelling inaccuracy

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -16,7 +16,7 @@
 				<key>modifiers</key>
 				<integer>1048576</integer>
 				<key>modifiersubtext</key>
-				<string>Open synonims for this word in your browser</string>
+				<string>Open synonyms for this word in your browser</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -49,7 +49,7 @@
 				<key>modifiers</key>
 				<integer>1048576</integer>
 				<key>modifiersubtext</key>
-				<string>Open synonims for this word in your browser</string>
+				<string>Open synonyms for this word in your browser</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -343,7 +343,7 @@ CTRL+enter (^↩️) opens antonyms in browser</string>
 		<key>B08999FE-6061-49C9-997E-42C21568C633</key>
 		<dict>
 			<key>note</key>
-			<string>Open Synonims in browser</string>
+			<string>Open synonyms in browser</string>
 			<key>xpos</key>
 			<real>650</real>
 			<key>ypos</key>


### PR DESCRIPTION
Update three instances of ~`synonims`~ in `src/info.plist` to `synonyms`.